### PR TITLE
ModelFormSet support + form revalidation

### DIFF
--- a/formwizard/forms.py
+++ b/formwizard/forms.py
@@ -236,6 +236,9 @@ class FormWizard(object):
         if issubclass(self.form_list[step], forms.ModelForm):
             kwargs.update({'instance':
                 self.get_form_instance(request, storage, step)})
+        elif issubclass(self.form_list[step], forms.models.BaseModelFormSet):
+            kwargs.update({'queryset':
+                self.get_form_instance(request, storage, step)})
         return self.form_list[step](**kwargs)
 
     def process_step(self, request, storage, form):

--- a/formwizard/forms.py
+++ b/formwizard/forms.py
@@ -137,6 +137,15 @@ class FormWizard(object):
                     self.determine_step(request, storage)),
             )
         else:
+            # Check if form was refreshed
+            current_step = self.determine_step(request, storage)
+            prev_step = self.get_prev_step(request, storage, step=current_step)
+            for value in request.POST:
+                if prev_step and not value.startswith(current_step) and value.startswith(prev_step):
+                    # form refreshed, change current step
+                    storage.set_current_step(prev_step)
+                    break
+
             form = self.get_form(request, storage, data=request.POST,
                 files=request.FILES)
             if form.is_valid():

--- a/formwizard/tests/formtests.py
+++ b/formwizard/tests/formtests.py
@@ -157,6 +157,18 @@ class FormTests(TestCase):
         testform.render_done(request, storage, None)
         self.assertEqual(storage.get_current_step(), 'start')
 
+    def test_form_refresh(self):
+        testform = TestWizard('formwizard.storage.session.SessionStorage', [('start', Step1), ('step2', UserFormSet)])
+
+        request = get_request({'start-name': 'foo'})
+        request.method = 'POST'
+
+        response, storage = testform(request, testmode=True)
+        self.assertEqual(storage.get_current_step(), 'step2')
+        # refresh form
+        response, storage = testform(request, testmode=True)
+        self.assertEqual(storage.get_current_step(), 'step2')
+
 class SessionFormTests(TestCase):
     def test_init(self):
         request = get_request()


### PR DESCRIPTION
Add ModelFormSet support (instance_list)
Keep previous step if form is refreshed, to get the correct form corresponding to the posted data - prevent 500 error if next form is a formset (missing ManagementForm data)
