### PR TITLE
Fix to allow GET parameters on links to wizards

### DIFF
--- a/formwizard/forms.py
+++ b/formwizard/forms.py
@@ -529,8 +529,13 @@ class NamedUrlFormWizard(FormWizard):
                 self.update_extra_context(request, storage,
                     kwargs['extra_context'])
 
+            if request.GET:
+                query_string = "?%s" % request.GET.urlencode()
+            else:
+                query_string = ""
             return HttpResponseRedirect(reverse(self.url_name,
-                kwargs={'step': self.determine_step(request, storage)}))
+                kwargs={'step': self.determine_step(request, storage)}) +
+                query_string)
         else:
             if 'extra_context' in kwargs:
                 self.update_extra_context(request, storage,


### PR DESCRIPTION
Assume we have a wizard with the following steps and URLs:
Step 1: `/order/quantity`
Step 2: `/order/registration`
Step 3: `/order/verify`

Instead of linking to our first step, we link to `/order/` which allows us the flexibility to change the step URLs in the future.

Now assume we allow the wizard to be sent extra information through `GET` parameters such as an affiliate link or a redemption code.  Example: `/order/?code=85c3t4ce8`.

This commit will make `/order/?code=85c3t4ce8` redirect to `/order/quantity?code=85c3t4ce8` rather than `/order/quantity`.
