### PR TITLE
Allow GET parameters when linking to named URL form wizards

### DIFF
--- a/formwizard/forms.py
+++ b/formwizard/forms.py
@@ -529,8 +529,13 @@ class NamedUrlFormWizard(FormWizard):
                 self.update_extra_context(request, storage,
                     kwargs['extra_context'])
 
+            if request.GET:
+                query_string = "?%s" % request.GET.urlencode()
+            else:
+                query_string = ""
             return HttpResponseRedirect(reverse(self.url_name,
-                kwargs={'step': self.determine_step(request, storage)}))
+                kwargs={'step': self.determine_step(request, storage)}) +
+                query_string)
         else:
             if 'extra_context' in kwargs:
                 self.update_extra_context(request, storage,

--- a/formwizard/tests/namedwizardtests/tests.py
+++ b/formwizard/tests/namedwizardtests/tests.py
@@ -1,6 +1,7 @@
 import re
 from django.test import TestCase, Client
 from django.core.urlresolvers import reverse
+from django.http import QueryDict
 from django.contrib.auth.models import User
 
 from formwizard.forms import NamedUrlSessionFormWizard, NamedUrlCookieFormWizard
@@ -48,6 +49,17 @@ class NamedWizardTests(object):
         self.assertEqual(response.context['form_prev_step'], None)
         self.assertEqual(response.context['form_next_step'], 'form2')
         self.assertEqual(response.context['form_step_count'], 4)
+
+    def test_initial_call_with_params(self):
+        get_params = {'getvar1': 'getval1', 'getvar2': 'getval2'}
+        response = self.client.get(reverse('%s_start' % self.wizard_urlname), get_params)
+        self.assertEqual(response.status_code, 302)
+
+        # Test for proper redirect GET parameters
+        location = response['Location']
+        self.assertNotEqual(location.find('?'), -1)
+        querydict = QueryDict(location[location.find('?') + 1:])
+        self.assertEqual(dict(querydict.items()), get_params)
 
     def test_form_post_error(self):
         response = self.client.post(reverse(self.wizard_urlname, kwargs={'step':'form1'}))


### PR DESCRIPTION
This pull request is the same as [this one](https://github.com/stephrdev/django-formwizard/pull/8) but with test cases added.  Commits can be squashed or reworded as needed.
### Example scenario

Assume we have a wizard with the following steps and URLs:
Step 1: /order/quantity
Step 2: /order/registration
Step 3: /order/verify

Instead of linking to our first step, we link to /order/ which allows us the flexibility to change the step URLs in the future.

Now assume we allow the wizard to be sent extra information through GET parameters such as an affiliate link or a redemption code. Example: /order/?code=85c3t4ce8.

This commit will make /order/?code=85c3t4ce8 redirect to /order/quantity?code=85c3t4ce8 rather than /order/quantity.
