### PR TITLE
No message given when raising NoFileStorageConfigured

### DIFF
--- a/formwizard/views.py
+++ b/formwizard/views.py
@@ -163,7 +163,8 @@ class WizardView(TemplateView):
             for field in form.base_fields.itervalues():
                 if (isinstance(field, forms.FileField) and
                         not hasattr(cls, 'file_storage')):
-                    raise NoFileStorageConfigured
+                    raise NoFileStorageConfigured((u"'%s' must define 'file_storage' "
+                        u"in order to use forms containing FileField.") % (cls.__name__))
 
         # build the kwargs for the formwizard instances
         kwargs['form_list'] = init_form_list


### PR DESCRIPTION
So I've just added that exception message for missing file_storage so it would appear at top of debug page instead of having your scroll all the way down. 
