### PR TITLE
Enabled use of BaseInlineForm in formwizard

### DIFF
--- a/formwizard/views.py
+++ b/formwizard/views.py
@@ -382,6 +382,14 @@ class WizardView(TemplateView):
         if issubclass(self.form_list[step], forms.ModelForm):
             # If the form is based on ModelForm, add instance if available.
             kwargs.update({'instance': self.get_form_instance(step)})
+        elif issubclass(self.form_list[step], forms.models.BaseInlineFormSet):
+            # BaseInlineFormSet is based on ModelFormSet but has some significant differences.
+            # It breaks if initial is passed.
+            # Furthermore, you need to pass it an instance from which
+            # it gets the relationship needed, not a queryset.
+            # See Inline Formset docs here: https://docs.djangoproject.com/en/dev/topics/forms/modelforms/
+            del(kwargs['initial'])
+            kwargs.update({'instance': self.get_form_instance(step)})
         elif issubclass(self.form_list[step], forms.models.BaseModelFormSet):
             # If the form is based on ModelFormSet, add queryset if available.
             kwargs.update({'queryset': self.get_form_instance(step)})


### PR DESCRIPTION
When passing an inline form (generated by inlineformset_factory), formwizard would crash with a "invalid keyword: "initial") error.

inlineformset_factory produces a BaseInlineFormSet that is derived from BaseModelFormSet.  Unfortunately, it needs an "initial" object as opposed to a QuerySet to be properly initialized.

A quick example of how it may be used is as follows:

```
recipe = Recipe.objects.get(pk=recipe_id)
initial = {
    '0':recipe.recipe_creator,
    '1':recipe,
    '2':recipe,
}
view = RecipeWizard.as_view([RecipeCreatorForm,RecipeBase, inlineformset_factory(Recipe, RecipeStep))
```

There is more information about inlineformset_factory here:
https://docs.djangoproject.com/en/dev/topics/forms/modelforms/

First time I'm doing this, apologies in advance if there is any etiquette violations above. If you need anything else, please feel free to let me know so I can provide it.  Thank you!
