### PR TITLE
Prevent instance and queryset keyword argument from being destroyed

### DIFF
--- a/formwizard/views.py
+++ b/formwizard/views.py
@@ -380,11 +380,13 @@ class WizardView(TemplateView):
             'initial': self.get_form_initial(step),
         })
         if issubclass(self.form_list[step], forms.ModelForm):
-            # If the form is based on ModelForm, add instance if available.
-            kwargs.update({'instance': self.get_form_instance(step)})
+            # If the form is based on ModelForm, add instance if available
+            # and not previously set.
+            kwargs.setdefault('instance', self.get_form_instance(step))
         elif issubclass(self.form_list[step], forms.models.BaseModelFormSet):
-            # If the form is based on ModelFormSet, add queryset if available.
-            kwargs.update({'queryset': self.get_form_instance(step)})
+            # If the form is based on ModelFormSet, add queryset if available
+            # and not previous set.
+            kwargs.setdefault('queryset', self.get_form_instance(step))
         return self.form_list[step](**kwargs)
 
     def process_step(self, form):


### PR DESCRIPTION
See https://code.djangoproject.com/ticket/17677

The test cases didn't apply cleanly against the code from the patch I made against the django trunk, so I've left them out of this commit.
